### PR TITLE
Sidekiq without ActiveJob

### DIFF
--- a/app/jobs/main_job.rb
+++ b/app/jobs/main_job.rb
@@ -1,11 +1,13 @@
-class MainJob < ApplicationJob
-  queue_as :default
+class MainJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'default'
 
   AMOUNT_SUB_JOBS = 250_000
 
   def perform
     AMOUNT_SUB_JOBS.times do |index|
-      SubJob.perform_later(index)
+      SubJob.perform_async(index)
     end
   end
 end

--- a/app/jobs/sub_job.rb
+++ b/app/jobs/sub_job.rb
@@ -1,5 +1,7 @@
-class SubJob < ApplicationJob
-  queue_as :default
+class SubJob
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'default'
 
   def perform(index)
     puts "Performing Job with index ##{index}"

--- a/lib/tasks/sidekiq/test.rake
+++ b/lib/tasks/sidekiq/test.rake
@@ -1,6 +1,6 @@
 namespace :sidekiq do
   desc 'Sidekiq performance test with ActiveJob'
   task :test => :environment do
-    MainJob.perform_later
+    MainJob.perform_async
   end
 end


### PR DESCRIPTION
Using Sidekiq without ActiveJob reduces memory usage drastically. 

On my development machine with Rails 5.1.5, Ruby 2.4.3 and Sidekiq 5.1.1, running a test with 250_000 sub jobs, the results for the `MainJob` process are:

**With ActiveJob:**
Memory Usage: 522 MB
Time: 379.329 sec

**Without ActiveJob**
Memory Usage: 60 MB
Time: 121.536 sec

The concurrency has been set to 10.

The test can be run with `rake sidekiq:test` (start `sidekiq` before).